### PR TITLE
Fix pip-install error

### DIFF
--- a/src/z_ssmnet/z_nnmnet/training_docker/Dockerfile
+++ b/src/z_ssmnet/z_nnmnet/training_docker/Dockerfile
@@ -34,7 +34,8 @@ RUN SITE_PKG=`pip3 show nnunet | grep "Location:" | awk '{print $2}'` && \
 RUN pip3 install \
     picai_eval>=1.4.4 \
     picai_prep>=2.1.2 \
-    picai_baseline>=0.8.1
+    picai_baseline>=0.8.1 \
+    mlxtend==0.19.0
 
 # Install SSL required modules
 RUN pip3 install tensorboard 


### PR DESCRIPTION
There is a version mismatch with `scikit-learn` caused by `mlxtend`. We experienced the same when updating our baseline Docker container. Fixing `mlxtend` to version `0.19.0` resolves this issue.

Error:

```bash
Step 8/27 : RUN pip3 install     picai_eval>=1.4.4     picai_prep>=2.1.2     picai_baseline>=0.8.1
 ---> Running in 5c6ae80c8957
ERROR: After October 2020 you may experience errors when installing or updating packages. This is because pip will change the way that it resolves dependency conflicts.

We recommend you use --use-feature=2020-resolver to test your packages with the new resolver before it becomes the default.

mlxtend 0.21.0 requires scikit-learn>=1.0.2, but you'll have scikit-learn 0.23.2 which is incompatible.
```